### PR TITLE
support older browsers for the audiocontext/morse example

### DIFF
--- a/src/examples/morse/code.js
+++ b/src/examples/morse/code.js
@@ -47,7 +47,9 @@ function charToMorse(char) {
 }
 
 function morseModel() {
-  const audioCtx = new AudioContext();
+  const AudioContext = window.AudioContext // Default
+    || window.webkitAudioContext; // Safari and old versions of Chrome
+  const audioCtx = new AudioContext;
   const oscillator = audioCtx.createOscillator();
   const gainNode = audioCtx.createGain();
   oscillator.connect(gainNode);
@@ -219,7 +221,9 @@ function charToMorse(char) {
 }
 
 function morseModel() {
-  var audioCtx = new AudioContext();
+  var AudioContext = window.AudioContext // Default
+    || window.webkitAudioContext; // Safari and old versions of Chrome
+  var audioCtx = new AudioContext;
   var oscillator = audioCtx.createOscillator();
   var gainNode = audioCtx.createGain();
   oscillator.connect(gainNode);

--- a/src/examples/morse/demo.js
+++ b/src/examples/morse/demo.js
@@ -45,7 +45,9 @@ function charToMorse(char) {
 }
 
 function morseModel() {
-  const audioCtx = new AudioContext();
+  const AudioContext = window.AudioContext // Default
+    || window.webkitAudioContext; // Safari and old versions of Chrome
+  const audioCtx = new AudioContext;
   const oscillator = audioCtx.createOscillator();
   const gainNode = audioCtx.createGain();
   oscillator.connect(gainNode);


### PR DESCRIPTION
Example originally didn't work in Safari 10 for me.