### PR TITLE
Allow vertical button expansion to fit text

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -122,7 +122,7 @@ input {
 }
 
 .Demo-result button {
-  height: 18px;
+  min-height: 18px;
 }
 
 /* generic layout helpers */


### PR DESCRIPTION
This fixes the buttons being too small vertically in FF. 

resolves #6